### PR TITLE
Bugfixes

### DIFF
--- a/Configuration/NodeTypes.Consent.yaml
+++ b/Configuration/NodeTypes.Consent.yaml
@@ -177,8 +177,6 @@
                 label: 'i18n'
               edgeless:
                 label: 'i18n'
-              wire:
-                label: 'i18n'
       validation:
         Neos.Neos/Validation/NotEmptyValidator: []
         Neos.Neos/Validation/StringValidator: []

--- a/Configuration/NodeTypes.Consent.yaml
+++ b/Configuration/NodeTypes.Consent.yaml
@@ -192,6 +192,7 @@
           editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
             dataSourceIdentifier: 'soee-cookieconsent-palettes'
+            allowEmpty: true
     popupBackgroundColor:
       type: string
       defaultValue: null

--- a/Configuration/NodeTypes.Consent.yaml
+++ b/Configuration/NodeTypes.Consent.yaml
@@ -253,7 +253,7 @@
           editor: 'Soee.InspectorEditors/ColorPickerEditor'
       validation:
         Soee.Validators/Validation/ColorValidator: []
-    buttonLinkColor:
+    buttonBorderColor:
       type: string
       defaultValue: null
       ui:
@@ -289,7 +289,7 @@
           editor: 'Soee.InspectorEditors/ColorPickerEditor'
       validation:
         Soee.Validators/Validation/ColorValidator: []
-    highlightLinkColor:
+    highlightBorderColor:
       type: string
       defaultValue: null
       ui:

--- a/Resources/Private/Fusion/Prototypes/CookieConsent.fusion
+++ b/Resources/Private/Fusion/Prototypes/CookieConsent.fusion
@@ -12,12 +12,9 @@ prototype(Soee.CookieConsent:Consent) < prototype(Neos.Fusion:Tag) {
       allow = ${q(node).property('allowButtonText')}
       deny = ${q(node).property('denyButtonText')}
       link = ${q(node).property('policyLinkText')}
-      href = Neos.Neos:NodeUri {
-        node = ${q(node).property('policyLink')}
-        absolute = true
-
-        @if.linkIsSet = ${q(node).property('policyLink')}
-      }
+      href = ${q(node).property('policyLink')}
+      href.@process.convertUris = Neos.Neos:ConvertUris
+      href.@if.linkIsSet = ${q(node).property('policyLink')}
     }
     palette = Neos.Fusion:RawArray {
       popup = Neos.Fusion:RawArray {

--- a/Resources/Private/Fusion/Prototypes/CookieConsent.fusion
+++ b/Resources/Private/Fusion/Prototypes/CookieConsent.fusion
@@ -26,12 +26,12 @@ prototype(Soee.CookieConsent:Consent) < prototype(Neos.Fusion:Tag) {
       button = Neos.Fusion:RawArray {
         background =  ${selectedPalette.button.background || q(node).property('buttonBackgroundColor') || 'transparent'}
         text =  ${selectedPalette.button.text || q(node).property('buttonTextColor') || '#0f0'}
-        border =  ${selectedPalette.button.border || q(node).property('buttonLinkColor') || '#0f0'}
+        border =  ${selectedPalette.button.border || q(node).property('buttonBorderColor') || '#0f0'}
       }
       highlight = Neos.Fusion:RawArray {
         background =  ${selectedPalette.highlight.background || q(node).property('highlightBackgroundColor') || 'transparent'}
         text =  ${selectedPalette.highlight.text || q(node).property('highlightTextColor') || '#0f0'}
-        border =  ${selectedPalette.highlight.border || q(node).property('highlightLinkColor') || '#0f0'}
+        border =  ${selectedPalette.highlight.border || q(node).property('highlightBorderColor') || '#0f0'}
       }
     }
   }

--- a/Resources/Private/Fusion/Prototypes/CookieConsent.fusion
+++ b/Resources/Private/Fusion/Prototypes/CookieConsent.fusion
@@ -2,6 +2,7 @@ prototype(Soee.CookieConsent:Consent) < prototype(Neos.Fusion:Tag) {
   tagName = 'script'
 
   @context.settings = Neos.Fusion:RawArray {
+    @context.selectedPalette = ${q(node).property('palette') ? Configuration.setting('Soee.CookieConsent.palettes.' + q(node).property('palette') + '.colors') : null}
     type = ${q(node).property('type') ? q(node).property('type'):'info'}
     theme = ${q(node).property('layout') ? q(node).property('layout'):'block'}
     position = ${q(node).property('position') ? q(node).property('position'):'bottom'}
@@ -18,13 +19,19 @@ prototype(Soee.CookieConsent:Consent) < prototype(Neos.Fusion:Tag) {
     }
     palette = Neos.Fusion:RawArray {
       popup = Neos.Fusion:RawArray {
-        background =  '#000'
-        text = '#0f0'
+        background =  ${selectedPalette.popup.background || q(node).property('popupBackgroundColor') || '#000'}
+        text =  ${selectedPalette.popup.text || q(node).property('popupTextColor') || '#0f0'}
+        link =  ${selectedPalette.popup.link || q(node).property('popupLinkColor') || '#0f0'}
       }
       button = Neos.Fusion:RawArray {
-        background = 'transparent'
-        text = '#0f0'
-        border = '#0f0'
+        background =  ${selectedPalette.button.background || q(node).property('buttonBackgroundColor') || 'transparent'}
+        text =  ${selectedPalette.button.text || q(node).property('buttonTextColor') || '#0f0'}
+        border =  ${selectedPalette.button.border || q(node).property('buttonLinkColor') || '#0f0'}
+      }
+      highlight = Neos.Fusion:RawArray {
+        background =  ${selectedPalette.highlight.background || q(node).property('highlightBackgroundColor') || 'transparent'}
+        text =  ${selectedPalette.highlight.text || q(node).property('highlightTextColor') || '#0f0'}
+        border =  ${selectedPalette.highlight.border || q(node).property('highlightLinkColor') || '#0f0'}
       }
     }
   }

--- a/Resources/Private/Translations/de/NodeTypes/Consent.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Consent.xlf
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="Soee.CookieConsent" source-language="en" target-language="de" datatype="plaintext">
+		<body>
+
+			<trans-unit id="ui.label" xml:space="preserve">
+				<source>Cookie Consent</source>
+				<target state="translated">Cookie-Hinweis</target>
+			</trans-unit>
+
+			<trans-unit id="tabs.palette" xml:space="preserve">
+				<source>Color palette</source>
+				<target state="translated">Farbpalette</target>
+			</trans-unit>
+
+			<trans-unit id="groups.consent" xml:space="preserve">
+				<source>Cookie consent</source>
+				<target state="translated">Cookie-Hinweis</target>
+			</trans-unit>
+			<trans-unit id="groups.palette" xml:space="preserve">
+				<source>Palette</source>
+				<target state="translated">Palette</target>
+			</trans-unit>
+			<trans-unit id="groups.popup" xml:space="preserve">
+				<source>Popup</source>
+				<target state="translated">Popup</target>
+			</trans-unit>
+			<trans-unit id="groups.button" xml:space="preserve">
+				<source>Button</source>
+				<target state="translated">Button</target>
+			</trans-unit>
+			<trans-unit id="groups.highlight" xml:space="preserve">
+				<source>Highlight</source>
+				<target state="translated">Highlight</target>
+			</trans-unit>
+
+			<trans-unit id="properties.message" xml:space="preserve">
+				<source>Message</source>
+				<target state="translated">Text</target>
+			</trans-unit>
+			<trans-unit id="properties.dismissButtonText" xml:space="preserve">
+				<source>Button text</source>
+				<target state="translated">Buttonbeschriftung</target>
+			</trans-unit>
+			<trans-unit id="properties.allowButtonText" xml:space="preserve">
+				<source>Allow button text</source>
+				<target state="translated">Buttonbeschriftung anzeigen</target>
+			</trans-unit>
+			<trans-unit id="properties.denyButtonText" xml:space="preserve">
+				<source>Deny button text</source>
+				<target state="translated">"Ablehnen" Buttonbeschriftung</target>
+			</trans-unit>
+			<trans-unit id="properties.policyLinkText" xml:space="preserve">
+				<source>Policy link text</source>
+				<target state="translated">Datenschutzlink-Text</target>
+			</trans-unit>
+			<trans-unit id="properties.policyLink" xml:space="preserve">
+				<source>Policy page link</source>
+				<target state="translated">Datenschutzlink-Seite</target>
+			</trans-unit>
+			<trans-unit id="properties.type" xml:space="preserve">
+				<source>Type</source>
+				<target state="translated">Typ</target>
+			</trans-unit>
+			<trans-unit id="properties.type.selectBoxEditor.values.info" xml:space="preserve">
+				<source>info</source>
+				<target state="translated">info</target>
+			</trans-unit>
+			<trans-unit id="properties.type.selectBoxEditor.values.opt-in" xml:space="preserve">
+				<source>opt-in</source>
+				<target state="translated">opt-in</target>
+			</trans-unit>
+			<trans-unit id="properties.type.selectBoxEditor.values.opt-out" xml:space="preserve">
+				<source>opt-out</source>
+				<target state="translated">opt-out</target>
+			</trans-unit>
+			<trans-unit id="properties.position" xml:space="preserve">
+				<source>Position</source>
+				<target state="translated">Position</target>
+			</trans-unit>
+			<trans-unit id="properties.position.selectBoxEditor.values.top" xml:space="preserve">
+				<source>top</source>
+				<target state="translated">oben</target>
+			</trans-unit>
+			<trans-unit id="properties.position.selectBoxEditor.values.bottom" xml:space="preserve">
+				<source>bottom</source>
+				<target state="translated">unten</target>
+			</trans-unit>
+			<trans-unit id="properties.position.selectBoxEditor.values.bottom-left" xml:space="preserve">
+				<source>bottom left</source>
+				<target state="translated">unten links</target>
+			</trans-unit>
+			<trans-unit id="properties.position.selectBoxEditor.values.bottom-right" xml:space="preserve">
+				<source>bottom right</source>
+				<target state="translated">unten rechts</target>
+			</trans-unit>
+			<trans-unit id="properties.static" xml:space="preserve">
+				<source>Static</source>
+				<target state="translated">Statisch</target>
+			</trans-unit>
+			<trans-unit id="properties.layout" xml:space="preserve">
+				<source>Layout</source>
+				<target state="translated">Darstellung</target>
+			</trans-unit>
+			<trans-unit id="properties.layout.selectBoxEditor.values.block">
+				<source>Block</source>
+				<target>Block</target>
+			</trans-unit>
+			<trans-unit id="properties.layout.selectBoxEditor.values.classic">
+				<source>Classic</source>
+				<target>abgerundeter Button</target>
+			</trans-unit>
+			<trans-unit id="properties.layout.selectBoxEditor.values.edgeless">
+				<source>Without edges</source>
+				<target>Kantenlos</target>
+			</trans-unit>
+
+			<trans-unit id="properties.palette" xml:space="preserve">
+				<source>Color palette</source>
+				<target state="translated">Farbpalette</target>
+			</trans-unit>
+			<trans-unit id="properties.popupBackgroundColor" xml:space="preserve">
+				<source>Background color</source>
+				<target state="translated">Hintergrundfarbe</target>
+			</trans-unit>
+			<trans-unit id="properties.popupTextColor" xml:space="preserve">
+				<source>Text color</source>
+				<target state="translated">Textfarbe</target>
+			</trans-unit>
+			<trans-unit id="properties.popupLinkColor" xml:space="preserve">
+				<source>Link color</source>
+				<target state="translated">Linkfarbe</target>
+			</trans-unit>
+			<trans-unit id="properties.buttonBackgroundColor" xml:space="preserve">
+				<source>Background color</source>
+				<target state="translated">Hintergrundfarbe</target>
+			</trans-unit>
+			<trans-unit id="properties.buttonTextColor" xml:space="preserve">
+				<source>Text color</source>
+				<target state="translated">Textfarbe</target>
+			</trans-unit>
+			<trans-unit id="properties.buttonLinkColor" xml:space="preserve">
+				<source>Border color</source>
+				<target state="translated">Rahmenfarbe</target>
+			</trans-unit>
+			<trans-unit id="properties.highlightBackgroundColor" xml:space="preserve">
+				<source>Background color</source>
+				<target state="translated">Hintergrundfarbe</target>
+			</trans-unit>
+			<trans-unit id="properties.highlightTextColor" xml:space="preserve">
+				<source>Text color</source>
+				<target state="translated">Textfarbe</target>
+			</trans-unit>
+			<trans-unit id="properties.highlightLinkColor" xml:space="preserve">
+				<source>Border color</source>
+				<target state="translated">Rahmenfarbe</target>
+			</trans-unit>
+
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Translations/de/Settings.xlf
+++ b/Resources/Private/Translations/de/Settings.xlf
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="Soee.CookieConsent" source-language="en" target-language="de" datatype="plaintext">
+		<body>
+
+			<trans-unit id="palettes.black-yellow" xml:space="preserve">
+				<source>black - yellow</source>
+				<target>Schwarz / Gelb</target>
+			</trans-unit>
+			<trans-unit id="palettes.aquamarine-blue" xml:space="preserve">
+				<source>aquamarine - blue</source>
+				<target>Aquamarin / Blau</target>
+			</trans-unit>
+			<trans-unit id="palettes.prussian-blue" xml:space="preserve">
+				<source>prussian blue - blue</source>
+				<target>Preußisch-Blau / Blau</target>
+			</trans-unit>
+			<trans-unit id="palettes.black-green">
+				<source>black - green</source>
+				<target>Schwarz / Grün</target>
+			</trans-unit>
+			<trans-unit id="palettes.blue-purple">
+				<source>blue - purple</source>
+				<target>Blau / Lila</target>
+			</trans-unit>
+			<trans-unit id="palettes.cyclamen-violet">
+				<source>cyclam - violet</source>
+				<target>Cyclam / Violet</target>
+			</trans-unit>
+			<trans-unit id="palettes.blue-white">
+				<source>blue - white</source>
+				<target>Blau / Weiß</target>
+			</trans-unit>
+			<trans-unit id="palettes.sanguine-red">
+				<source>sanguine-red</source>
+				<target>Blutrot</target>
+			</trans-unit>
+
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Consent.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Consent.xlf
@@ -106,8 +106,8 @@
 			<trans-unit id="properties.buttonTextColor" xml:space="preserve">
 				<source>Text color</source>
 			</trans-unit>
-			<trans-unit id="properties.buttonLinkColor" xml:space="preserve">
-				<source>Link color</source>
+			<trans-unit id="properties.buttonBorderColor" xml:space="preserve">
+				<source>Border color</source>
 			</trans-unit>
 			<trans-unit id="properties.highlightBackgroundColor" xml:space="preserve">
 				<source>Background color</source>
@@ -115,8 +115,8 @@
 			<trans-unit id="properties.highlightTextColor" xml:space="preserve">
 				<source>Text color</source>
 			</trans-unit>
-			<trans-unit id="properties.highlightLinkColor" xml:space="preserve">
-				<source>Link color</source>
+			<trans-unit id="properties.highlightBorderColor" xml:space="preserve">
+				<source>Border color</source>
 			</trans-unit>
 
 		</body>

--- a/Resources/Private/Translations/en/NodeTypes/Consent.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Consent.xlf
@@ -3,7 +3,121 @@
 	<file original="" product-name="Soee.CookieConsent" source-language="en" datatype="plaintext">
 		<body>
 
+			<trans-unit id="ui.label" xml:space="preserve">
+				<source>Cookie Consent</source>
+			</trans-unit>
 
+			<trans-unit id="tabs.palette" xml:space="preserve">
+				<source>Color palette</source>
+			</trans-unit>
+
+			<trans-unit id="groups.consent" xml:space="preserve">
+				<source>Cookie consent</source>
+			</trans-unit>
+			<trans-unit id="groups.palette" xml:space="preserve">
+				<source>Palette</source>
+			</trans-unit>
+			<trans-unit id="groups.popup" xml:space="preserve">
+				<source>Popup</source>
+			</trans-unit>
+			<trans-unit id="groups.button" xml:space="preserve">
+				<source>Button</source>
+			</trans-unit>
+			<trans-unit id="groups.highlight" xml:space="preserve">
+				<source>Highlight</source>
+			</trans-unit>
+
+			<trans-unit id="properties.message" xml:space="preserve">
+				<source>Message</source>
+			</trans-unit>
+			<trans-unit id="properties.dismissButtonText" xml:space="preserve">
+				<source>Button text</source>
+			</trans-unit>
+			<trans-unit id="properties.allowButtonText" xml:space="preserve">
+				<source>Allow button text</source>
+			</trans-unit>
+			<trans-unit id="properties.denyButtonText" xml:space="preserve">
+				<source>Deny button text</source>
+			</trans-unit>
+			<trans-unit id="properties.policyLinkText" xml:space="preserve">
+				<source>Policy link text</source>
+			</trans-unit>
+			<trans-unit id="properties.policyLink" xml:space="preserve">
+				<source>Policy page link</source>
+			</trans-unit>
+			<trans-unit id="properties.type" xml:space="preserve">
+				<source>Type</source>
+			</trans-unit>
+			<trans-unit id="properties.type.selectBoxEditor.values.info" xml:space="preserve">
+				<source>info</source>
+			</trans-unit>
+			<trans-unit id="properties.type.selectBoxEditor.values.opt-in" xml:space="preserve">
+				<source>opt-in</source>
+			</trans-unit>
+			<trans-unit id="properties.type.selectBoxEditor.values.opt-out" xml:space="preserve">
+				<source>opt-out</source>
+			</trans-unit>
+			<trans-unit id="properties.position" xml:space="preserve">
+				<source>Position</source>
+			</trans-unit>
+			<trans-unit id="properties.position.selectBoxEditor.values.top" xml:space="preserve">
+				<source>top</source>
+			</trans-unit>
+			<trans-unit id="properties.position.selectBoxEditor.values.bottom" xml:space="preserve">
+				<source>bottom</source>
+			</trans-unit>
+			<trans-unit id="properties.position.selectBoxEditor.values.bottom-left" xml:space="preserve">
+				<source>bottom left</source>
+			</trans-unit>
+			<trans-unit id="properties.position.selectBoxEditor.values.bottom-right" xml:space="preserve">
+				<source>bottom right</source>
+			</trans-unit>
+			<trans-unit id="properties.static" xml:space="preserve">
+				<source>Static</source>
+			</trans-unit>
+			<trans-unit id="properties.layout" xml:space="preserve">
+				<source>Layout</source>
+			</trans-unit>
+			<trans-unit id="properties.layout.selectBoxEditor.values.block">
+				<source>Block</source>
+			</trans-unit>
+			<trans-unit id="properties.layout.selectBoxEditor.values.classic">
+				<source>Classic</source>
+			</trans-unit>
+			<trans-unit id="properties.layout.selectBoxEditor.values.edgeless">
+				<source>Without edges</source>
+			</trans-unit>
+
+			<trans-unit id="properties.palette" xml:space="preserve">
+				<source>Color palette</source>
+			</trans-unit>
+			<trans-unit id="properties.popupBackgroundColor" xml:space="preserve">
+				<source>Background color</source>
+			</trans-unit>
+			<trans-unit id="properties.popupTextColor" xml:space="preserve">
+				<source>Text color</source>
+			</trans-unit>
+			<trans-unit id="properties.popupLinkColor" xml:space="preserve">
+				<source>Link color</source>
+			</trans-unit>
+			<trans-unit id="properties.buttonBackgroundColor" xml:space="preserve">
+				<source>Background color</source>
+			</trans-unit>
+			<trans-unit id="properties.buttonTextColor" xml:space="preserve">
+				<source>Text color</source>
+			</trans-unit>
+			<trans-unit id="properties.buttonLinkColor" xml:space="preserve">
+				<source>Link color</source>
+			</trans-unit>
+			<trans-unit id="properties.highlightBackgroundColor" xml:space="preserve">
+				<source>Background color</source>
+			</trans-unit>
+			<trans-unit id="properties.highlightTextColor" xml:space="preserve">
+				<source>Text color</source>
+			</trans-unit>
+			<trans-unit id="properties.highlightLinkColor" xml:space="preserve">
+				<source>Link color</source>
+			</trans-unit>
 
 		</body>
 	</file>

--- a/Resources/Private/Translations/en/Settings.xlf
+++ b/Resources/Private/Translations/en/Settings.xlf
@@ -6,6 +6,27 @@
 			<trans-unit id="palettes.black-yellow" xml:space="preserve">
 				<source>black - yellow</source>
 			</trans-unit>
+			<trans-unit id="palettes.aquamarine-blue" xml:space="preserve">
+				<source>aquamarine - blue</source>
+			</trans-unit>
+			<trans-unit id="palettes.prussian-blue" xml:space="preserve">
+				<source>prussian blue - blue</source>
+			</trans-unit>
+			<trans-unit id="palettes.black-green">
+				<source>black - green</source>
+			</trans-unit>
+			<trans-unit id="palettes.blue-purple">
+				<source>blue - purple</source>
+			</trans-unit>
+			<trans-unit id="palettes.cyclamen-violet">
+				<source>cyclam - violet</source>
+			</trans-unit>
+			<trans-unit id="palettes.blue-white">
+				<source>blue - white</source>
+			</trans-unit>
+			<trans-unit id="palettes.sanguine-red">
+				<source>sanguine-red</source>
+			</trans-unit>
 
 		</body>
 	</file>

--- a/Resources/Private/Translations/pl/NodeTypes/Consent.xlf
+++ b/Resources/Private/Translations/pl/NodeTypes/Consent.xlf
@@ -127,9 +127,9 @@
 				<source>Text color</source>
 				<target xml:lang="pl" state="translated">Kolor tekstu</target>
 			</trans-unit>
-			<trans-unit id="properties.buttonLinkColor" xml:space="preserve">
-				<source>Link color</source>
-				<target xml:lang="pl" state="translated">Kolor linku</target>
+			<trans-unit id="properties.buttonBorderColor" xml:space="preserve">
+				<source>Border color</source>
+				<target xml:lang="pl" >Kolor obrzeża</target>
 			</trans-unit>
 			<trans-unit id="properties.highlightBackgroundColor" xml:space="preserve">
 				<source>Background color</source>
@@ -139,9 +139,9 @@
 				<source>Text color</source>
 				<target xml:lang="pl" state="translated">Kolor tekstu</target>
 			</trans-unit>
-			<trans-unit id="properties.highlightLinkColor" xml:space="preserve">
-				<source>Link color</source>
-				<target xml:lang="pl" state="translated">Kolor linku</target>
+			<trans-unit id="properties.highlightBorderColor" xml:space="preserve">
+				<source>Border color</source>
+				<target xml:lang="pl" >Kolor obrzeża</target>
 			</trans-unit>
 
 		</body>


### PR DESCRIPTION
Having all these properties on a content element is convenient, however currently it is unusable.
Hence some changes:
* fix broken policy-link
* add missing fusion configuration for actually using configured colors
* add missing translations

Unfortunately the color-pickers don't allow the user to insert color-codes, so the color-selection on this plugin is a good idea, but not feasible for adapting the element to your site's theme with exact color values.
